### PR TITLE
Feature/add continuous shooting mode

### DIFF
--- a/main.html
+++ b/main.html
@@ -255,6 +255,20 @@
                                             data-name="Right" fill="none" id="Right-2" points="7.9 12.3 12 16.3 16.1 12.3" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></polyline> <line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="2.7" y2="14.2"></line> </g> </g> </g> </g> </g></svg>
                 save
             </button>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
+                <label class="form-check-label" for="flexSwitchCheckDefault"><span>Enable continuous shooting</span>
+                    <span type="button" class="badge rounded-pill bg-info" data-bs-toggle="tooltip" data-bs-placement="right"
+                        data-bs-title="Animation does not start when changing idol, costume, or type. The image will be downloaded automatically. Check the animation list’s checkboxes to animate.">
+                        <!-- "Info lg" icon from Bootstrap Icons -->
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-lg"
+                            viewBox="0 0 16 16">
+                            <path
+                                d="m9.708 6.075-3.024.379-.108.502.595.108c.387.093.464.232.38.619l-.975 4.577c-.255 1.183.14 1.74 1.067 1.74.72 0 1.554-.332 1.933-.789l.116-.549c-.263.232-.65.325-.905.325-.363 0-.494-.255-.402-.704l1.323-6.208Zm.091-2.755a1.32 1.32 0 1 1-2.64 0 1.32 1.32 0 0 1 2.64 0Z" />
+                        </svg>
+                    </span>
+                </label>
+            </div>
         </div>
         <div class="p-0 col-lg-9 d-flex">
             <canvas id="canvas" width="1136" height="640" class="img-fluid"></canvas>

--- a/main.html
+++ b/main.html
@@ -256,7 +256,7 @@
                 save
             </button>
             <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
+                <input id="continuousShootingModeSwitch" class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
                 <label class="form-check-label" for="flexSwitchCheckDefault"><span>Enable continuous shooting</span>
                     <span type="button" class="badge rounded-pill bg-info" data-bs-toggle="tooltip" data-bs-placement="right"
                         data-bs-title="Animation does not start when changing idol, costume, or type. The image will be downloaded automatically. Check the animation list’s checkboxes to animate.">

--- a/main.html
+++ b/main.html
@@ -250,6 +250,11 @@
                     </g></svg>
                 share
             </button>
+            <button class="btn btn-secondary mb-3" type="button" id="download" onclick="saveImage()">
+                <svg viewBox="0 0 24 24" width="20" height="20" xmlns="http://www.w3.org/2000/svg" fill="#000000"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <title></title> <g id="Complete"> <g id="download"> <g> <path d="M3,12.3v7a2,2,0,0,0,2,2H19a2,2,0,0,0,2-2v-7" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path> <g> <polyline
+                                            data-name="Right" fill="none" id="Right-2" points="7.9 12.3 12 16.3 16.1 12.3" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></polyline> <line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="2.7" y2="14.2"></line> </g> </g> </g> </g> </g></svg>
+                save
+            </button>
         </div>
         <div class="p-0 col-lg-9 d-flex">
             <canvas id="canvas" width="1136" height="640" class="img-fluid"></canvas>

--- a/main.html
+++ b/main.html
@@ -244,8 +244,12 @@
             <input type="button" class="btn btn-info mb-3" id="showThanks" data-bs-toggle="modal"
                 data-bs-target="#divThanks" value="Special Thanks">
 
-            <input type="button" class="btn btn-success mb-3" id="copyToClipboard"
-                value="Share Current Spine!" onclick="copyLinkToClipboard()">
+            <button class="btn btn-secondary mb-3" type="button" id="copyToClipboard" onclick="copyLinkToClipboard()">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <g id="Communication / Share_Android"> <path id="Vector"
+                                d="M9 13.5L15 16.5M15 7.5L9 10.5M18 21C16.3431 21 15 19.6569 15 18C15 16.3431 16.3431 15 18 15C19.6569 15 21 16.3431 21 18C21 19.6569 19.6569 21 18 21ZM6 15C4.34315 15 3 13.6569 3 12C3 10.3431 4.34315 9 6 9C7.65685 9 9 10.3431 9 12C9 13.6569 7.65685 15 6 15ZM18 9C16.3431 9 15 7.65685 15 6C15 4.34315 16.3431 3 18 3C19.6569 3 21 4.34315 21 6C21 7.65685 19.6569 9 18 9Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path> </g>
+                    </g></svg>
+                share
+            </button>
         </div>
         <div class="p-0 col-lg-9 d-flex">
             <canvas id="canvas" width="1136" height="640" class="img-fluid"></canvas>

--- a/main.js
+++ b/main.js
@@ -531,16 +531,19 @@ function copyLinkToClipboard() {
 async function saveImage() {
     const renderer = app.renderer;
     const image = await renderer.extract.image(cont);
-
     const anchor = document.createElement('a');
-
     const idolName = document.getElementById("idolList").selectedOptions[0].text;
     const optionElement = document.getElementById("dressList").selectedOptions[0];
     const dressCategory = optionElement.parentNode.label;
     const dressName = optionElement.text;
     const dressType = document.getElementById("typeList").selectedOptions[0].text;
     const fileName = `${idolName}-${dressCategory}-${dressName}-${dressType}.png`;
-    anchor.download = fileName;
+    // Windows: <>:"/\|?*
+    // macOS/Linux : /
+    const invalidRagex = /[<>:"\/\\|?*\x00-\x1F]/g; 
+    const validFileName = fileName.replace(invalidRagex, '_');
+
+    anchor.download = validFileName;
     anchor.href = image.src;
     // Trigger a click event on the anchor element to initiate the download
     anchor.click();

--- a/main.js
+++ b/main.js
@@ -4,6 +4,9 @@ const dropLoader = PIXI.Assets, cont = new PIXI.Container();
 const SML0 = "sml_cloth0", SML1 = "sml_cloth1", BIG0 = "big_cloth0", BIG1 = "big_cloth1";
 const urlParams = new URLSearchParams(window.location.search);
 
+// State
+let isContinuousShootingEnabled = false
+
 const idolMap = new Map();
 const spineMap = new Map();
 
@@ -139,6 +142,12 @@ async function init() {
     resetBtn.onclick = () => {
         resetAllAnimation();
     }
+
+    const continuousShootingModeSwitch = document.getElementById("continuousShootingModeSwitch")
+    continuousShootingModeSwitch.addEventListener("change", (event) => {
+        isContinuousShootingEnabled = event.target.checked
+        // console.info(`enableContinuousShooting:${isContinuousShootingEnabled}`) 
+    })
 
     fetch("https://api.shinycolors.moe/spine/idollist").then(async (response) => {
         const idolInfo = await response.json();
@@ -482,7 +491,7 @@ const clearState = (spine) => {
     spine.lastTime = null;
 };
 async function renderToStage(currentSpine) {
-    clearState(currentSpine)
+    if (isContinuousShootingEnabled) { clearState(currentSpine) }
     cont.removeChild(cont.children[0]);
     cont.addChild(currentSpine);
 
@@ -509,7 +518,7 @@ async function renderToStage(currentSpine) {
     cont.pivot.set(contLocalBound.width / 2, contLocalBound.height / 2);
     cont.position.set(app.view.width / 2, app.view.height / 2);
 
-    await saveImage();
+    if (isContinuousShootingEnabled) { await saveImage(); }
 }
 
 function resetAllAnimation() {

--- a/main.js
+++ b/main.js
@@ -529,15 +529,19 @@ function copyLinkToClipboard() {
 }
 
 async function saveImage() {
-    const renderer = app.renderer;
-    const image = await renderer.extract.image(cont);
+  const renderer = app.renderer;
+  const image = await renderer.extract.image(cont);
 
-    const anchor = document.createElement('a');
-    const dressList = document.getElementById("dressList");
-    const dressType = document.getElementById("typeList").value;
-    const enzaId = dressList.options[dressList.selectedIndex].getAttribute("enzaId");
-    anchor.download = `${enzaId}-${dressType}.png`;
-    anchor.href = image.src;
-    // Trigger a click event on the anchor element to initiate the download
-    anchor.click();
+  const anchor = document.createElement('a');
+
+  const idolName = document.getElementById("idolList").selectedOptions[0].text;
+  const optionElement = document.getElementById("dressList").selectedOptions[0];
+  const dressCategory = optionElement.parentNode.label;
+  const dressName = optionElement.text;
+  const dressType = document.getElementById("typeList").selectedOptions[0].text;
+  const fileName = `${idolName}-${dressCategory}-${dressName}-${dressType}.png`;
+  anchor.download = fileName;
+  anchor.href = image.src;
+  // Trigger a click event on the anchor element to initiate the download
+  anchor.click();
 }

--- a/main.js
+++ b/main.js
@@ -83,7 +83,7 @@ async function renderByDrop(dataTexture) {
     const spineAtlasLoader = new PIXI.spine.core.AtlasAttachmentLoader(spineAtlas);
     const spineJsonParser = new PIXI.spine.core.SkeletonJson(spineAtlasLoader);
     const spineData = spineJsonParser.readSkeletonData(rawJson);
-    setupAnimationList(spineData);
+    await setupAnimationList(spineData);
 }
 
 function toastInit() {
@@ -140,7 +140,7 @@ async function init() {
         idolInfo.forEach((element) => {
             idolInfoMap.set(element.idolId, element);
         });
-        setupIdolList(idolInfoMap);
+        await setupIdolList(idolInfoMap);
     });
 
     _hello();
@@ -158,7 +158,7 @@ function _hello() {
     console.log(...log);
 }
 
-function setupIdolList(idolInfo) {
+async function setupIdolList(idolInfo) {
     const idolList = document.getElementById("idolList");
     let idolId = urlParams.has("idolId") ? Number(urlParams.get("idolId")) : 1,
         idolName = idolInfo.get(idolId).idolName;
@@ -174,13 +174,13 @@ function setupIdolList(idolInfo) {
         idolList.appendChild(option);
     });
 
-    idolList.onchange = () => {
+    idolList.onchange = async () => {
         idolId = idolList.value;
         idolName = idolInfo.get(Number(idolId)).idolName;
-        testAndLoadDress(idolId, idolName);
+        await testAndLoadDress(idolId, idolName);
     };
 
-    testAndLoadDress(idolId, idolName);
+    await testAndLoadDress(idolId, idolName);
 }
 /*
 function testAndLoadPreset(idolId) {
@@ -198,27 +198,27 @@ function setupPreset(presetList) {
 
 }
 
-function testAndLoadDress(idolId, idolName) {
+async function testAndLoadDress(idolId, idolName) {
     if (!idolMap.has(idolName)) {
         if (idolId == 0) {
             fetch(`https://cf-static.shinycolors.moe/others/hazuki.json`).then(async (response) => {
                 idolMap.set(idolName, await response.json());
-                setupDressList(idolMap.get(idolName));
+                await setupDressList(idolMap.get(idolName));
             });
         }
         else {
             fetch(`https://api.shinycolors.moe/spine/dressList?idolId=${idolId}`).then(async (response) => {
                 idolMap.set(idolName, await response.json());
-                setupDressList(idolMap.get(idolName));
+                await setupDressList(idolMap.get(idolName));
             });
         }
     }
     else {
-        setupDressList(idolMap.get(idolName));
+        await setupDressList(idolMap.get(idolName));
     }
 }
 
-function setupDressList(idolDressList) {
+async function setupDressList(idolDressList) {
     const dressList = document.getElementById("dressList");
     dressList.innerHTML = "";
 
@@ -258,15 +258,15 @@ function setupDressList(idolDressList) {
     });
     dressList.appendChild(optGroup);
 
-    dressList.onchange = () => {
+    dressList.onchange = async () => {
         arrayOrder = dressList.value;
-        setupTypeList(idolDressList[arrayOrder]);
+        await setupTypeList(idolDressList[arrayOrder]);
     };
 
-    setupTypeList(idolDressList[arrayOrder]);
+    await setupTypeList(idolDressList[arrayOrder]);
 }
 
-function setupTypeList(dressObj) {
+async function setupTypeList(dressObj) {
     const typeList = document.getElementById("typeList");
     let dressType;
     typeList.innerHTML = "";
@@ -351,50 +351,50 @@ function setupTypeList(dressObj) {
         }
     }
 
-    typeList.onchange = () => {
+    typeList.onchange = async () => {
         const dressList = document.getElementById("dressList");
         dressType = typeList.value;
 
         if (dressObj.idolId == 0) {
-            testAndLoadAnimation(dressList.options[dressList.selectedIndex].getAttribute("path"), dressType, true);
+            await testAndLoadAnimation(dressList.options[dressList.selectedIndex].getAttribute("path"), dressType, true);
         }
         else {
-            testAndLoadAnimation(dressList.options[dressList.selectedIndex].getAttribute("enzaId"), dressType);
+            await testAndLoadAnimation(dressList.options[dressList.selectedIndex].getAttribute("enzaId"), dressType);
         }
     };
 
     if (dressObj.idolId == 0) {
-        testAndLoadAnimation(dressObj.path, dressType, true);
+        await testAndLoadAnimation(dressObj.path, dressType, true);
     }
     else {
-        testAndLoadAnimation(dressObj.enzaId, dressType);
+        await testAndLoadAnimation(dressObj.enzaId, dressType);
     }
 
 }
 
-function testAndLoadAnimation(enzaId, type, flag = false) {
+async function testAndLoadAnimation(enzaId, type, flag = false) {
     if (!spineMap.has(`${enzaId}/${type}`)) {
         if (flag) {
-            PIXI.Assets.load(`https://cf-static.shinycolors.moe/spine/sub_characters/${migrateMap[type]}/${enzaId}`).then((resource) => {
+            PIXI.Assets.load(`https://cf-static.shinycolors.moe/spine/sub_characters/${migrateMap[type]}/${enzaId}`).then(async (resource) => {
                 const waifu = resource.spineData;
                 spineMap.set(`${enzaId}/${type}`, waifu);
-                setupAnimationList(waifu);
+                await setupAnimationList(waifu);
             });
         }
         else {
-            PIXI.Assets.load(`https://cf-static.shinycolors.moe/spine/idols/${migrateMap[type]}/${enzaId}/data.json`).then((resource) => {
+            PIXI.Assets.load(`https://cf-static.shinycolors.moe/spine/idols/${migrateMap[type]}/${enzaId}/data.json`).then(async (resource) => {
                 const waifu = resource.spineData;
                 spineMap.set(`${enzaId}/${type}`, waifu);
-                setupAnimationList(waifu);
+                await setupAnimationList(waifu);
             });
         }
     }
     else {
-        setupAnimationList(spineMap.get(`${enzaId}/${type}`));
+        await setupAnimationList(spineMap.get(`${enzaId}/${type}`));
     }
 }
 
-function setupAnimationList(spineData) {
+async function setupAnimationList(spineData) {
     const animationList = document.getElementById("divAnimationBody");
     animationList.innerHTML = "";
 
@@ -447,7 +447,7 @@ function setupAnimationList(spineData) {
         currentSpine.state.setAnimation(0, currentSpine.spineData.animations[0].name, true);
     }
 
-    renderToStage(currentSpine);
+    await renderToStage(currentSpine);
 }
 
 function animationOnChange(theInput, trackNo, currentSpine) {
@@ -471,7 +471,7 @@ function blobToBase64(blob) {
     });
 }
 
-function renderToStage(currentSpine) {
+async function renderToStage(currentSpine) {
     cont.removeChild(cont.children[0]);
     cont.addChild(currentSpine);
 
@@ -497,6 +497,8 @@ function renderToStage(currentSpine) {
     cont.scale.set(scale);
     cont.pivot.set(contLocalBound.width / 2, contLocalBound.height / 2);
     cont.position.set(app.view.width / 2, app.view.height / 2);
+
+    await saveImage();
 }
 
 function resetAllAnimation() {

--- a/main.js
+++ b/main.js
@@ -98,6 +98,11 @@ function toastInit() {
     }
 }
 
+function tooltipInit() {
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+}
+
 function toMobileUI() {
     window.location.href = "https://mspine.shinycolors.moe";
 }
@@ -115,6 +120,7 @@ async function init() {
     }
 
     toastInit();
+    tooltipInit();
     const canvas = document.getElementById("canvas"), resetBtn = document.getElementById("resetAnimation");
 
     app = new PIXI.Application({

--- a/main.js
+++ b/main.js
@@ -470,8 +470,13 @@ function blobToBase64(blob) {
         reader.readAsDataURL(blob);
     });
 }
-
+const clearState = (spine) => {
+    spine.state.clearTracks();
+    spine.skeleton.setToSetupPose();
+    spine.lastTime = null;
+};
 async function renderToStage(currentSpine) {
+    clearState(currentSpine)
     cont.removeChild(cont.children[0]);
     cont.addChild(currentSpine);
 

--- a/main.js
+++ b/main.js
@@ -529,19 +529,19 @@ function copyLinkToClipboard() {
 }
 
 async function saveImage() {
-  const renderer = app.renderer;
-  const image = await renderer.extract.image(cont);
+    const renderer = app.renderer;
+    const image = await renderer.extract.image(cont);
 
-  const anchor = document.createElement('a');
+    const anchor = document.createElement('a');
 
-  const idolName = document.getElementById("idolList").selectedOptions[0].text;
-  const optionElement = document.getElementById("dressList").selectedOptions[0];
-  const dressCategory = optionElement.parentNode.label;
-  const dressName = optionElement.text;
-  const dressType = document.getElementById("typeList").selectedOptions[0].text;
-  const fileName = `${idolName}-${dressCategory}-${dressName}-${dressType}.png`;
-  anchor.download = fileName;
-  anchor.href = image.src;
-  // Trigger a click event on the anchor element to initiate the download
-  anchor.click();
+    const idolName = document.getElementById("idolList").selectedOptions[0].text;
+    const optionElement = document.getElementById("dressList").selectedOptions[0];
+    const dressCategory = optionElement.parentNode.label;
+    const dressName = optionElement.text;
+    const dressType = document.getElementById("typeList").selectedOptions[0].text;
+    const fileName = `${idolName}-${dressCategory}-${dressName}-${dressType}.png`;
+    anchor.download = fileName;
+    anchor.href = image.src;
+    // Trigger a click event on the anchor element to initiate the download
+    anchor.click();
 }


### PR DESCRIPTION
Related Issue: #7

@alex94539 
Hi. I adjusted the UI and created a PR. I would be happy if you could try it out and consider merging it.

>  [!NOTE]
> This is a prototype to verify implementation. (PC only)

# overview
- Add "Continuous shooting mode"
  - Animation does not start when changing idol, costume, or type
  - The image will be downloaded automatically.

# How to check operation
I use local overrides in Chrome's Developer Tools.  
I replace the code in 

- [PC site](https://spine.shinycolors.moe/) and [mobile site](https://mspine.shinycolors.moe/) main.js
- PC site root ( `main.html` on the repository)  

# Check Items
- [disabled] Previous functions work normally (even if you change the character, dress, type, or animation, it animates. Images are not automatically downloaded)
- [enabled] Animation does not start even after switching idols, costumes, and types
- [enabled] Download images when switching idols, costumes, and types.
- [enabled] Animation works when you change checkbox in animation List.
- [disabled] Return to normal operation after turning off continuous shooting mode.